### PR TITLE
fix(postcard) remove duplicated comma to tags listing

### DIFF
--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -40,7 +40,7 @@ const isExternal = !!post.data.externalLink;
     <span class="post-tags">
       {post.data.tags.map((tag, index) => (
         <>
-          <a href={`${base}tags/${tag}/`}>{tag}</a>{index < post.data.tags.length - 1 && ', '}
+          <a href={`${base}tags/${tag}/`}>{tag}</a>
         </>
       ))}
     </span>


### PR DESCRIPTION
The comma between the tags of the postcard compoment are duplicated, i didnt checked why, but its possible to fix by removing 1 line in src/components/postcard.astro

```astro
<span class="post-tags">
                {post.data.tags.map((tag, index) => (
                    <>
                        <a href={`${base}tags/${tag}/`}>{tag}</a>
                        >>>>>>>{index < post.data.tags.length - 1 && ", "}
                    </>
                ))}
            </span>
```

<img width="1153" height="156" alt="Pasted image" src="https://github.com/user-attachments/assets/599a0227-badb-4583-aa95-377bb5c3fe48" />

