### PR TITLE
Remove duplicate ', ' after tag links

### DIFF
--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -38,7 +38,7 @@ const isExternal = !!post.data.externalLink;
   </div>
   {post.data.tags && post.data.tags.length > 0 && (
     <span class="post-tags">
-      {post.data.tags.map((tag, index) => (
+      {post.data.tags.map((tag) => (
         <>
           <a href={`${base}tags/${tag}/`}>{tag}</a>
         </>

--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -40,7 +40,7 @@ const isExternal = !!post.data.externalLink;
     <span class="post-tags">
       {post.data.tags.map((tag, index) => (
         <>
-          <a href={`${base}tags/${tag}/`}>{tag}</a>{index < post.data.tags.length - 1 && ', '}
+          <a href={`${base}tags/${tag}/`}>{tag}</a>
         </>
       ))}
     </span>


### PR DESCRIPTION
No need to specify commas after tag links using js, as commas already added using css.


Before:
<img width="829" height="307" alt="Screenshot 2025-10-27 at 22 15 32" src="https://github.com/user-attachments/assets/06718e2b-b01d-4a84-9b18-ee32d7e11ea9" />
After:
<img width="821" height="259" alt="Screenshot 2025-10-27 at 22 15 48" src="https://github.com/user-attachments/assets/58595ba2-917c-484a-b77e-7f9ab82adebd" />
