### PR TITLE
Fix objective-c code block in example post

### DIFF
--- a/src/content/posts/code-blocks-examples.md
+++ b/src/content/posts/code-blocks-examples.md
@@ -242,7 +242,7 @@ echo "Hello, World!"
 ### O
 
 **Objective-C:**
-```objectivec
+```objective-c
 #import <Foundation/Foundation.h>
 int main() {
     @autoreleasepool {


### PR DESCRIPTION
Code block for Objective-C in code examples post currently looks like this:

![Screenshot_2025-11-14-00-41-23-509_org mozilla firefox-edit](https://github.com/user-attachments/assets/cfed020e-cdf8-43f9-ada8-5516c444c2c7)

Probably because of updating dependencies, fixed it by updating language identifier.